### PR TITLE
FIX: Use `matmul` instead of `mm` in `backward`

### DIFF
--- a/python/eetq/modules/qlinear.py
+++ b/python/eetq/modules/qlinear.py
@@ -87,7 +87,7 @@ class EetqLinearMMFunction(Function):
         
         if ctx.needs_input_grad[0]:
             # 2D matrix multiplication, unsqueeze to 3D
-            grad_input = grad_output.squeeze(0).mm(
+            grad_input = grad_output.squeeze(0).matmul(
                 weight.transpose(0, 1)
             ).unsqueeze(0)
 


### PR DESCRIPTION
Fixes the current PEFT integration with EETQ !
Using `mm` leads to surprising shape mismatch errors (as I think this does not support broadcasting), using `matmul` resolves it as it enables broadcasting

cc @dingjingzhen 