### PR TITLE
Fix deprecated `includes_path` parameter

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -87,7 +87,7 @@ for item in sources:
     sources[sources.index(item)] = os.path.join(current_dir, item)
 
 include_paths = []
-include_paths.append(cpp_extension.include_paths(cuda=True))    # cuda path
+include_paths.append(cpp_extension.include_paths(device_type='cuda'))    # cuda path
 include_paths.append(os.path.join(current_dir, 'csrc'))
 include_paths.append(os.path.join(current_dir, 'csrc/utils'))
 include_paths.append(os.path.join(current_dir, 'csrc/cutlass/include'))


### PR DESCRIPTION
With change [pytorch@67735d1ee825473a57e5b4e2fb227780613cca7d](https://github.com/pytorch/pytorch/commit/67735d1ee825473a57e5b4e2fb227780613cca7d) the parameter `cuda` of `include_paths` was generalized to `device_type`. This patch reflects that change. 

Before this patch, running `python setup.py build` with PyTorch 2.6 results in:

```plain
$ python setup.py 
  cpu = _conversion_method_template(device=torch.device("cpu"))
Traceback (most recent call last):
  File "/home/nemo/code/eetq/githubnemo/setup.py", line 90, in <module>
    include_paths.append(cpp_extension.include_paths(cuda=True))    # cuda path
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: include_paths() got an unexpected keyword argument 'cuda'
```

I could not test the installation fully since my local CUDA setup was mucking around but at least the `TypeError` is resolved.